### PR TITLE
chore: Added metadata.yaml and metadata.display.yaml for ADC compliance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ docker_test_integration:
 .PHONY: docker_test_lint
 docker_test_lint:
 	docker run --rm -it \
+		-e ENABLE_BPMETADATA=1 \
 		-e EXCLUDE_LINT_DIRS \
 		-v "$(CURDIR)":/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
@@ -77,9 +78,10 @@ docker_test_lint:
 .PHONY: docker_generate_docs
 docker_generate_docs:
 	docker run --rm -it \
+		-e ENABLE_BPMETADATA=1 \
 		-v "$(CURDIR)":/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
-		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs'
+		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs display'
 
 # Generate metadata
 .PHONY: docker_generate_metadata_w_display

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -15,6 +15,7 @@
  */
 module "bigtable" {
   source       = "GoogleCloudPlatform/bigtable/google"
+  version      = "0.1.0"
   project_id   = var.project_id
   name         = "bigtable-tf1"
   display_name = "bigtable-tf1"

--- a/metadata.display.yaml
+++ b/metadata.display.yaml
@@ -1,0 +1,53 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintMetadata
+metadata:
+  name: terraform-google-bigtable-display
+  annotations:
+    config.kubernetes.io/local-config: "true"
+spec:
+  info:
+    title: terraform-google-bigtable
+    source:
+      repo: https://github.com/GoogleCloudPlatform/terraform-google-bigtable.git
+      sourceType: git
+  ui:
+    input:
+      variables:
+        deletion_protection:
+          name: deletion_protection
+          title: Deletion Protection
+        display_name:
+          name: display_name
+          title: Display Name
+        labels:
+          name: labels
+          title: Labels
+        name:
+          name: name
+          title: Name
+        project_id:
+          name: project_id
+          title: Project Id
+        storage_type:
+          name: storage_type
+          title: Storage Type
+        tables:
+          name: tables
+          title: Tables
+        zones:
+          name: zones
+          title: Zones

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,0 +1,113 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: blueprints.cloud.google.com/v1alpha1
+kind: BlueprintMetadata
+metadata:
+  name: terraform-google-bigtable
+  annotations:
+    config.kubernetes.io/local-config: "true"
+spec:
+  info:
+    title: terraform-google-bigtable
+    source:
+      repo: https://github.com/GoogleCloudPlatform/terraform-google-bigtable.git
+      sourceType: git
+    version: 0.0.1
+    actuationTool:
+      flavor: Terraform
+      version: ">= 1.3"
+    description: {}
+    icon: assets/icon.png
+  content:
+    examples:
+      - name: basic
+        location: examples/basic
+  interfaces:
+    variables:
+      - name: project_id
+        description: The ID of the project in which the resource belongs
+        varType: string
+        required: true
+      - name: name
+        description: The unique name of the Bigtable instance.
+        varType: string
+        required: true
+      - name: display_name
+        description: The human-readable display name of the Bigtable instance. Defaults to the instance name
+        varType: string
+        required: true
+      - name: deletion_protection
+        description: Whether or not to allow Terraform to destroy the instance
+        varType: bool
+        defaultValue: true
+      - name: storage_type
+        description: The storage type to use. One of SSD or HDD. Defaults to SSD
+        varType: string
+        defaultValue: SSD
+      - name: zones
+        description: Zones of the Bigtable cluster.
+        varType: |-
+          map(object({
+              zone         = string
+              cluster_id   = string
+              num_nodes    = optional(number)
+              kms_key_name = optional(string)
+              autoscaling_config = optional(object({
+                min_nodes      = number
+                max_nodes      = number
+                cpu_target     = number
+                storage_target = optional(number)
+              }))
+            }))
+        required: true
+      - name: labels
+        description: labels associated to the Bigtable instance.
+        varType: map(string)
+        defaultValue: {}
+      - name: tables
+        description: Tables to created in the Bigtable instance.
+        varType: |-
+          map(object({
+              table_name              = string
+              split_keys              = optional(list(string))
+              deletion_protection     = optional(string)
+              change_stream_retention = optional(number)
+              column_family = optional(map(object({
+                family = string
+                }))
+              )
+            }))
+        defaultValue: {}
+    outputs:
+      - name: instance_id
+        description: Bigtable instance id
+      - name: instance_name
+        description: Bigtable instance name
+      - name: table_ids
+        description: List of table being provisioned
+  requirements:
+    roles:
+      - level: Project
+        roles:
+          - roles/owner
+    services:
+      - cloudresourcemanager.googleapis.com
+      - storage-api.googleapis.com
+      - serviceusage.googleapis.com
+      - bigtableadmin.googleapis.com
+      - bigtable.googleapis.com
+    providerVersions:
+      - source: hashicorp/google
+        version: ">= 3.53, < 7"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -93,10 +93,15 @@ spec:
     outputs:
       - name: instance_id
         description: Bigtable instance id
+        type: string
       - name: instance_name
         description: Bigtable instance name
+        type: string
       - name: table_ids
         description: List of table being provisioned
+        type:
+          - tuple
+          - - string
   requirements:
     roles:
       - level: Project


### PR DESCRIPTION
Adding metadata files for Bigtable terraform blueprint according to go/adc-authoring.
