### PR TITLE
chore: Updated roles in metadata.yaml

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -106,7 +106,11 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/owner
+          - roles/bigtable.admin
+          - roles/cloudkms.admin
+          - roles/iam.serviceAccountAdmin
+          - roles/serviceusage.serviceUsageAdmin
+          - roles/resourcemanager.projectIamAdmin
     services:
       - cloudresourcemanager.googleapis.com
       - storage-api.googleapis.com

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -16,7 +16,11 @@
 
 locals {
   int_required_roles = [
-    "roles/owner"
+    "roles/bigtable.admin",
+    "roles/cloudkms.admin",
+    "roles/iam.serviceAccountAdmin",
+    "roles/serviceusage.serviceUsageAdmin",
+    "roles/resourcemanager.projectIamAdmin"
   ]
 }
 


### PR DESCRIPTION
Updated roles in metadata.yaml since existing permissions were overly permissive. The `owner` role has been replaced with the roles required to utilize the APIs mentioned in the `services` section.