### PR TITLE
feat: per module requirements configs for bigtable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.25.4
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.25
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 
@@ -81,7 +81,7 @@ docker_generate_docs:
 		-e ENABLE_BPMETADATA=1 \
 		-v "$(CURDIR)":/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
-		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs display --per-module-requirements'
+		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs --display --per-module-requirements'
 
 # Generate metadata
 .PHONY: docker_generate_metadata_w_display

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.23
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.25.4
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 
@@ -81,7 +81,7 @@ docker_generate_docs:
 		-e ENABLE_BPMETADATA=1 \
 		-v "$(CURDIR)":/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
-		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs display'
+		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs display --per-module-requirements'
 
 # Generate metadata
 .PHONY: docker_generate_metadata_w_display

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -131,17 +131,17 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/bigtable.admin
           - roles/cloudkms.admin
           - roles/iam.serviceAccountAdmin
           - roles/serviceusage.serviceUsageAdmin
           - roles/resourcemanager.projectIamAdmin
+          - roles/bigtable.admin
     services:
-      - cloudresourcemanager.googleapis.com
-      - storage-api.googleapis.com
-      - serviceusage.googleapis.com
-      - bigtableadmin.googleapis.com
       - bigtable.googleapis.com
+      - bigtableadmin.googleapis.com
+      - cloudresourcemanager.googleapis.com
+      - serviceusage.googleapis.com
+      - storage-api.googleapis.com
     providerVersions:
       - source: hashicorp/google
         version: ">= 3.53, < 7"

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -15,13 +15,17 @@
  */
 
 locals {
-  int_required_roles = [
-    "roles/bigtable.admin",
-    "roles/cloudkms.admin",
-    "roles/iam.serviceAccountAdmin",
-    "roles/serviceusage.serviceUsageAdmin",
-    "roles/resourcemanager.projectIamAdmin"
-  ]
+  per_module_roles = {
+    root = [
+      "roles/bigtable.admin",
+      "roles/cloudkms.admin",
+      "roles/iam.serviceAccountAdmin",
+      "roles/serviceusage.serviceUsageAdmin",
+      "roles/resourcemanager.projectIamAdmin"
+    ]
+  }
+
+  int_required_roles = tolist(toset(flatten(values(local.per_module_roles))))
 }
 
 resource "google_service_account" "int_test" {

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -14,6 +14,18 @@
  * limitations under the License.
  */
 
+locals {
+  per_module_services = {
+    root = [
+      "cloudresourcemanager.googleapis.com",
+      "storage-api.googleapis.com",
+      "serviceusage.googleapis.com",
+      "bigtableadmin.googleapis.com",
+      "bigtable.googleapis.com"
+    ]
+  }
+}
+
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 18.0"
@@ -24,11 +36,5 @@ module "project" {
   folder_id         = var.folder_id
   billing_account   = var.billing_account
 
-  activate_apis = [
-    "cloudresourcemanager.googleapis.com",
-    "storage-api.googleapis.com",
-    "serviceusage.googleapis.com",
-    "bigtableadmin.googleapis.com",
-    "bigtable.googleapis.com"
-  ]
+  activate_apis = tolist(toset(flatten(values(local.per_module_services))))
 }


### PR DESCRIPTION
Introduced:

- per_module_roles: to config required roles to run each sub modules.
- per_module_service: to config required services to run each sub modules.

Added feature flag `--per-module-requirements` to generate_docs cmd, to align with the per module configs.