### PR TITLE
feat: Update Google provider version constraint to < 8

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.53, < 7"
+      version = ">= 3.53, < 8"
     }
   }
 


### PR DESCRIPTION
feat: Update Google provider version constraint to < 8 for Bigtable.

This is being done to resolve error related to version incompatibility while deploying connection between vertex-ai-agent-engine and bigtable.

Bigtable metadata schema validation successfully done:
https://paste.googleplex.com/4828469346304000

Successful connection deployment in staging:

vertex-ai-agent-engine & bigtable:
app deployment: https://screenshot.googleplex.com/9mxpSwUxBSgWWP8
Connection params: https://screenshot.googleplex.com/6kMAnK4f4wEmB2s